### PR TITLE
Add multilingual privacy policy pages

### DIFF
--- a/public/privacy-policy-en.html
+++ b/public/privacy-policy-en.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy - MyBud</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; margin: 2rem;">
+  <h1>Privacy Policy</h1>
+  <p><strong>Last updated:</strong> March 15, 2025</p>
+  <p>This policy integrates the privacy and cookie terms in compliance with the Brazilian General Data Protection Law (LGPD Law No. 13,709/2018) and international data protection regulations.</p>
+  <p>We at MyBud take your privacy seriously. This document explains how we collect, use, store, and protect your information when using our platform.</p>
+
+  <h2>1. Legal Bases for Processing</h2>
+  <p>All data processing is based on the following legal bases:</p>
+  <ul>
+    <li>Explicit consent (Art. 7, I LGPD)</li>
+    <li>Contract performance (Art. 7, V LGPD)</li>
+    <li>Legitimate interest (Art. 7, IX LGPD)</li>
+    <li>Compliance with legal obligation (Art. 7, II LGPD)</li>
+  </ul>
+
+  <h2>2. Data Collected</h2>
+  <ul>
+    <li>Personal data: name, email.</li>
+    <li>Technical data: IP, device type</li>
+    <li>Navigation data: visited pages, interactions, session time</li>
+    <li>Metadata: records of actions performed on the platform</li>
+  </ul>
+
+  <h2>3. Cookie Policy</h2>
+  <p>We only use essential and analytics cookies, as detailed below:</p>
+  <h3>Essential Cookies</h3>
+  <ul>
+    <li>Purpose: authentication, security and basic functions</li>
+    <li>Examples: session maintenance, fraud prevention</li>
+    <li>Control: always active, do not require consent</li>
+  </ul>
+  <h3>Analytics Cookies</h3>
+  <ul>
+    <li>Tool: Google Analytics (anonymized data)</li>
+    <li>We collect: aggregated browsing behavior</li>
+    <li>Duration: 14 months</li>
+    <li>Control: active only with consent</li>
+  </ul>
+  <p>Management: control your cookies through the cookie icon button in the lower right corner of the screen.</p>
+
+  <h2>4. Purposes of Processing</h2>
+  <ul>
+    <li>Provide and improve the contracted services</li>
+    <li>Personalize the user experience</li>
+    <li>Facilitate communication with associations, partners and other growers</li>
+    <li>Security and fraud prevention</li>
+    <li>Statistical analysis of platform usage</li>
+    <li>Compliance with regulatory obligations</li>
+  </ul>
+
+  <h2>5. Data Sharing</h2>
+  <ul>
+    <li>Technology partners: hosting and infrastructure</li>
+    <li>Analytics platforms: Google Analytics (anonymized data)</li>
+    <li>Authorities: upon valid court order</li>
+    <li>Service providers: companies that assist in operating the platform under confidentiality agreements</li>
+    <li>Corporate group: for internal administrative purposes</li>
+  </ul>
+
+  <h2>6. Your Rights</h2>
+  <ul>
+    <li>Full access to stored data</li>
+    <li>Correction of inaccurate information</li>
+    <li>Data portability to other services</li>
+    <li>Deletion of non-essential data</li>
+    <li>Revocation of granted consents</li>
+  </ul>
+
+  <h2>7. Security Measures</h2>
+  <ul>
+    <li>Encryption for sensitive data</li>
+    <li>Continuous vulnerability monitoring</li>
+    <li>Periodic penetration testing</li>
+    <li>Daily backups</li>
+  </ul>
+
+  <h2>8. Data Retention</h2>
+  <ul>
+    <li>Registration data: up to 5 years after last interaction</li>
+    <li>Access logs: 6 months</li>
+    <li>Analytics data: 2 years in anonymized format</li>
+    <li>Financial information: 10 years according to tax legislation</li>
+  </ul>
+
+  <h2>9. Policy Updates</h2>
+  <p>We will notify about significant changes through:</p>
+  <ul>
+    <li>Email to registered address</li>
+    <li>Public log of changes on our website</li>
+  </ul>
+
+  <h2>10. Contact and Exercising Rights</h2>
+  <p><strong>MyBud Contact</strong><br />
+  contact@mybud.app</p>
+  <p><strong>National Data Protection Authority (ANPD)</strong><br />
+  Response Time: 15 business days<br />
+  Art. 19 of the LGPD</p>
+</body>
+</html>

--- a/public/privacy-policy-es.html
+++ b/public/privacy-policy-es.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Política de Privacidad - MyBud</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; margin: 2rem;">
+  <h1>Política de Privacidad</h1>
+  <p><strong>Última actualización:</strong> 15 de marzo de 2025</p>
+  <p>Esta política integra los términos de privacidad y uso de cookies en conformidad con la LGPD brasileña (Ley 13.709/2018) y las normativas internacionales de protección de datos.</p>
+  <p>En MyBud nos tomamos tu privacidad en serio. Este documento detalla cómo recopilamos, utilizamos, almacenamos y protegemos tu información al usar nuestra plataforma.</p>
+
+  <h2>1. Bases legales para el tratamiento</h2>
+  <p>Todo tratamiento de datos se fundamenta en las siguientes bases legales:</p>
+  <ul>
+    <li>Consentimiento explícito (Art. 7º, I LGPD)</li>
+    <li>Ejecución de contrato (Art. 7º, V LGPD)</li>
+    <li>Interés legítimo (Art. 7º, IX LGPD)</li>
+    <li>Cumplimiento de obligación legal (Art. 7º, II LGPD)</li>
+  </ul>
+
+  <h2>2. Datos recopilados</h2>
+  <ul>
+    <li>Datos personales: nombre, correo electrónico.</li>
+    <li>Datos técnicos: IP, tipo de dispositivo</li>
+    <li>Datos de navegación: páginas visitadas, interacciones, tiempo de sesión</li>
+    <li>Metadatos: registros de operaciones realizadas en la plataforma</li>
+  </ul>
+
+  <h2>3. Política de cookies</h2>
+  <p>Utilizamos solo cookies esenciales y analíticas, conforme se detalla a continuación:</p>
+  <h3>Cookies esenciales</h3>
+  <ul>
+    <li>Finalidad: autenticación, seguridad y funciones básicas</li>
+    <li>Ejemplos: mantenimiento de sesión, prevención de fraude</li>
+    <li>Control: siempre activas, no requieren consentimiento</li>
+  </ul>
+  <h3>Cookies analíticas</h3>
+  <ul>
+    <li>Herramienta: Google Analytics (datos anonimizados)</li>
+    <li>Recopilamos: comportamiento agregado de navegación</li>
+    <li>Duración: 14 meses</li>
+    <li>Control: activas solo con consentimiento</li>
+  </ul>
+  <p>Gestión: controla tus cookies mediante el botón con ícono de galleta en la esquina inferior derecha de la pantalla.</p>
+
+  <h2>4. Finalidades del tratamiento</h2>
+  <ul>
+    <li>Provisión y mejora de los servicios contratados</li>
+    <li>Personalización de la experiencia del usuario</li>
+    <li>Facilitar la comunicación con asociaciones, socios y otros cultivadores</li>
+    <li>Seguridad y prevención de actividades fraudulentas</li>
+    <li>Análisis estadístico del uso de la plataforma</li>
+    <li>Cumplimiento de obligaciones regulatorias</li>
+  </ul>
+
+  <h2>5. Compartición de datos</h2>
+  <ul>
+    <li>Socios tecnológicos: alojamiento e infraestructura</li>
+    <li>Plataformas analíticas: Google Analytics (datos anonimizados)</li>
+    <li>Autoridades: mediante requerimiento judicial válido</li>
+    <li>Prestadores de servicios: empresas que ayudan en la operación de la plataforma bajo contrato de confidencialidad</li>
+    <li>Grupo empresarial: con fines administrativos internos</li>
+  </ul>
+
+  <h2>6. Tus derechos</h2>
+  <ul>
+    <li>Acceso completo a los datos almacenados</li>
+    <li>Rectificación de información inexacta</li>
+    <li>Portabilidad de datos a otros servicios</li>
+    <li>Eliminación de datos no esenciales</li>
+    <li>Revocación de consentimientos otorgados</li>
+  </ul>
+
+  <h2>7. Medidas de seguridad</h2>
+  <ul>
+    <li>Cifrado para datos sensibles</li>
+    <li>Monitoreo continuo de vulnerabilidades</li>
+    <li>Pruebas periódicas de penetración</li>
+    <li>Copias de seguridad diarias</li>
+  </ul>
+
+  <h2>8. Retención de datos</h2>
+  <ul>
+    <li>Datos de registro: hasta 5 años tras la última interacción</li>
+    <li>Registros de acceso: 6 meses</li>
+    <li>Datos analíticos: 2 años en formato anonimizado</li>
+    <li>Información financiera: 10 años según legislación tributaria</li>
+  </ul>
+
+  <h2>9. Actualizaciones de la política</h2>
+  <p>Notificaremos sobre cambios significativos mediante:</p>
+  <ul>
+    <li>Comunicación al correo electrónico registrado</li>
+    <li>Registro público de cambios en nuestro sitio web</li>
+  </ul>
+
+  <h2>10. Contacto y ejercicio de derechos</h2>
+  <p><strong>Contacto MyBud</strong><br />
+  contact@mybud.app</p>
+  <p><strong>Autoridad Nacional de Protección de Datos (ANPD)</strong><br />
+  Plazo de respuesta: 15 días hábiles<br />
+  Art. 19 de la LGPD</p>
+</body>
+</html>

--- a/public/privacy-policy-pt.html
+++ b/public/privacy-policy-pt.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Política de Privacidade - MyBud</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; margin: 2rem;">
+  <h1>Política de Privacidade</h1>
+  <p><strong>Última atualização:</strong> 15 de março de 2025</p>
+  <p>Esta Política integra os termos de privacidade e uso de cookies em conformidade com a LGPD (Lei 13.709/2018) e regulamentações internacionais de proteção de dados.</p>
+  <p>Nós, do MyBud, levamos sua privacidade a sério. Este documento detalha como coletamos, utilizamos, armazenamos e protegemos suas informações ao usar nossa plataforma.</p>
+
+  <h2>1. Bases Legais para o Tratamento</h2>
+  <p>Todo tratamento de dados realizado fundamenta-se nas seguintes bases legais:</p>
+  <ul>
+    <li>Consentimento explícito (Art. 7º, I LGPD)</li>
+    <li>Execução de contrato (Art. 7º, V LGPD)</li>
+    <li>Interesse legítimo (Art. 7º, IX LGPD)</li>
+    <li>Cumprimento de obrigação legal (Art. 7º, II LGPD)</li>
+  </ul>
+
+  <h2>2. Dados Coletados</h2>
+  <ul>
+    <li>Dados pessoais: nome, e-mail.</li>
+    <li>Dados técnicos: IP, tipo de dispositivo</li>
+    <li>Dados de navegação: páginas visitadas, interações, tempo de sessão</li>
+    <li>Metadados: registros de operações realizadas na plataforma</li>
+  </ul>
+
+  <h2>3. Política de Cookies</h2>
+  <p>Utilizamos apenas cookies essenciais e de análise, conforme detalhado abaixo:</p>
+  <h3>Cookies Essenciais</h3>
+  <ul>
+    <li>Finalidade: autenticação, segurança e funcionalidades básicas</li>
+    <li>Exemplos: manutenção de sessão, prevenção a fraude</li>
+    <li>Controle: ativos sempre, não requerem consentimento</li>
+  </ul>
+  <h3>Cookies Analíticos</h3>
+  <ul>
+    <li>Ferramenta: Google Analytics (dados anonimizados)</li>
+    <li>Coletamos: comportamento agregado de navegação</li>
+    <li>Duração: 14 meses</li>
+    <li>Controle: ativo apenas com consentimento</li>
+  </ul>
+  <p>Gerenciamento: controle seus cookies através do botão com ícone de cookie no canto inferior direito da tela.</p>
+
+  <h2>4. Finalidades do Tratamento</h2>
+  <ul>
+    <li>Fornecimento e melhoria dos serviços contratados</li>
+    <li>Personalização da experiência do usuário</li>
+    <li>Facilitar a comunicação com associações, parceiros e outros growers</li>
+    <li>Segurança e prevenção a atividades fraudulentas</li>
+    <li>Análise estatística de uso da plataforma</li>
+    <li>Cumprimento de obrigações regulatórias</li>
+  </ul>
+
+  <h2>5. Compartilhamento de Dados</h2>
+  <ul>
+    <li>Parceiros tecnológicos: hospedagem e infraestrutura</li>
+    <li>Plataformas analíticas: Google Analytics (dados anonimizados)</li>
+    <li>Autoridades: mediante requisição judicial válida</li>
+    <li>Prestadores de serviço: empresas que auxiliam na operação da plataforma, sob contrato de confidencialidade</li>
+    <li>Grupo empresarial: para fins administrativos internos</li>
+  </ul>
+
+  <h2>6. Seus Direitos</h2>
+  <ul>
+    <li>Acesso completo aos dados armazenados</li>
+    <li>Retificação de informações inexatas</li>
+    <li>Portabilidade de dados para outros serviços</li>
+    <li>Eliminação de dados não essenciais</li>
+    <li>Revogação de consentimentos concedidos</li>
+  </ul>
+
+  <h2>7. Medidas de Segurança</h2>
+  <ul>
+    <li>Criptografia para dados sensíveis</li>
+    <li>Monitoramento contínuo de vulnerabilidades</li>
+    <li>Testes periódicos de penetração</li>
+    <li>Backups diários</li>
+  </ul>
+
+  <h2>8. Retenção de Dados</h2>
+  <ul>
+    <li>Dados cadastrais: até 5 anos após última interação</li>
+    <li>Registros de acesso: 6 meses</li>
+    <li>Dados analíticos: 2 anos em formato anonimizado</li>
+    <li>Informações financeiras: 10 anos conforme legislação tributária</li>
+  </ul>
+
+  <h2>9. Atualizações da Política</h2>
+  <p>Notificaremos sobre alterações significativas através de:</p>
+  <ul>
+    <li>Comunicação por e-mail registrado</li>
+    <li>Registro público de alterações em nosso site</li>
+  </ul>
+
+  <h2>10. Contato e Exercício de Direitos</h2>
+  <p><strong>Contato MyBud</strong><br />
+  contact@mybud.app</p>
+  <p><strong>Autoridade Nacional de Proteção de Dados (ANPD)</strong><br />
+  Prazo para Resposta: 15 dias úteis<br />
+  Art. 19 da LGPD</p>
+</body>
+</html>

--- a/src/react-app/components/Footer.tsx
+++ b/src/react-app/components/Footer.tsx
@@ -134,7 +134,7 @@ const Footer: FC = () => {
         <div className="border-t border-gray-100 mt-8 pt-6">
           <div className="flex justify-center items-center gap-6 mb-4">
             <a
-              href="#"
+              href={`/privacy-policy-${currentLanguage}.html`}
               className="text-sm text-gray-500 hover:text-emerald-600 transition-colors"
             >
               {t('footer.privacy')}


### PR DESCRIPTION
## Summary
- add Portuguese, English, and Spanish privacy policy pages
- link footer to language-specific policy

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689603459450832894e7a084dbdee449